### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/talentlink-connector-product/zip.xml
+++ b/talentlink-connector-product/zip.xml
@@ -12,7 +12,7 @@
       <includes>
         <include>product.json</include>
         <include>openapi.json</include>
-        <include>README.md</include>
+        <include>README*.md</include>
         <include>**/*.png</include>
       </includes>
     </fileSet>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml